### PR TITLE
[port][patch][cors] prevent 500 error on malformed CORS request

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,13 @@ exports.register = function (server, options, next) {
 
         const versionedPath = options.basePath + 'v' + requestedVersion + request.path.slice(options.basePath.length - 1);
 
-        const method = request.method === 'options' ? request.headers['access-control-request-method'] : request.method;
+        let method = request.method;
+        if (request.method === 'options') {
+            method = request.headers['access-control-request-method'];
+            if (!method) {
+                return reply(Boom.badRequest('The Access-Control-Request-Method header must be set for CORS requests.'));
+            }
+        }
 
         const route = server.match(method, versionedPath);
 

--- a/test/index.js
+++ b/test/index.js
@@ -655,6 +655,34 @@ describe('Versioning', () => {
 
             done();
         });
+
+        it('should 400 when an OPTIONS request has a malformed access-control-request-method header', async () => {
+
+            server.route({
+                method: 'GET',
+                path: '/corstest',
+                handler: function (request, h) {
+
+                    return 'Testing CORS!';
+                },
+                config: {
+                    cors: {
+                        origin: ['*'],
+                        headers: ['Accept', 'Authorization']
+                    }
+                }
+            });
+
+            const response = await server.inject({
+                method: 'OPTIONS',
+                url: '/corstest',
+                headers: {
+                    'Origin': 'http://www.example.com',
+                    'Access-Control-Request-Method': ''
+                }
+            });
+            expect(response.statusCode).to.equal(400);
+        });
     });
 
     describe(' -> path parameters', () => {


### PR DESCRIPTION
Porting this commit: https://github.com/p-meier/hapi-api-version/commit/60ce23749e141537f7c3426712a4e80626e4f40b